### PR TITLE
Sample reader select

### DIFF
--- a/src/adiff.c
+++ b/src/adiff.c
@@ -70,7 +70,7 @@ static diff cmp(const lsf_wrapped a, const lsf_wrapped b) {
             .code = ret_code,
             .hunks = bdiff(
                 fi.sample_size * a.info.channels, fi.fetcher,
-                (void *) &a.file, (void *) &b.file)};
+                (void *) a.file, (void *) b.file)};
     }
     return (diff) {.code = ret_code};
 }

--- a/src/adiff.c
+++ b/src/adiff.c
@@ -38,13 +38,11 @@ static adiff_return_code info_cmp(const lsf_wrapped a, const lsf_wrapped b) {
 }
 
 static unsigned short_fetcher(void * source, unsigned n_items, char * buffer) {
-    lsf_wrapped const * const src = source;
-    return sf_readf_short(src->file, (short *) buffer, n_items);
+    return sf_readf_short((SNDFILE * const) source, (short *) buffer, n_items);
 }
 
 static unsigned float_fetcher(void * source, unsigned n_items, char * buffer) {
-    lsf_wrapped const * const src = source;
-    return sf_readf_float(src->file, (float *) buffer, n_items);
+    return sf_readf_float((SNDFILE * const) source, (float *) buffer, n_items);
 }
 
 typedef struct {
@@ -72,7 +70,7 @@ static diff cmp(const lsf_wrapped a, const lsf_wrapped b) {
             .code = ret_code,
             .hunks = bdiff(
                 fi.sample_size * a.info.channels, fi.fetcher,
-                (void *) &a, (void *) &b)};
+                (void *) &a.file, (void *) &b.file)};
     }
     return (diff) {.code = ret_code};
 }

--- a/src/adiff.c
+++ b/src/adiff.c
@@ -91,34 +91,34 @@ diff adiff(const_str path_a, const_str path_b) {
     return result;
 }
 
-static unsigned short_etcher(
+static unsigned short_writer(
         SNDFILE * const src, unsigned const n_items, char const * buffer) {
     return sf_writef_short(src, (short *) buffer, n_items);
 }
 
-static unsigned float_etcher(
+static unsigned float_writer(
         SNDFILE * const src, unsigned const n_items,
         char const * buffer) {
     return sf_writef_float(src, (float *) buffer, n_items);
 }
 
-typedef unsigned (*data_etcher)(
+typedef unsigned (*data_writer)(
     SNDFILE * const, unsigned const n_items, char const * buffer);
 
 typedef struct {
-    data_etcher const etcher;
+    data_writer const etcher;
     size_t const sample_size;
 } etcher_info;
 
-static etcher_info get_etcher(lsf_wrapped const f) {
+static etcher_info get_writer(lsf_wrapped const f) {
     if (
             ((f.info.format & SF_FORMAT_SUBMASK) == SF_FORMAT_FLOAT) |
             ((f.info.format & SF_FORMAT_SUBMASK) == SF_FORMAT_DOUBLE)) {
         return (etcher_info) {
-            .etcher = float_etcher, .sample_size = sizeof(float)};
+            .etcher = float_writer, .sample_size = sizeof(float)};
     } else {
         return (etcher_info) {
-            .etcher = short_etcher, .sample_size = sizeof(short)};
+            .etcher = short_writer, .sample_size = sizeof(short)};
     }
 }
 
@@ -128,7 +128,7 @@ static void copy_data(
     end--;
     sf_seek(in.file, start, SEEK_SET);  // Should be error checked (-1 rval)
     fetcher_info const fi = get_fetcher(in);
-    etcher_info const ei = get_etcher(in);
+    etcher_info const ei = get_writer(in);
     char buffer[8192];
     unsigned n_items = 8192 / ei.sample_size / in.info.channels;
     while (start < end) {

--- a/tests/unittest_adiff.c
+++ b/tests/unittest_adiff.c
@@ -158,7 +158,6 @@ static void diff_assertions(
     g_assert_nonnull(h2);
     g_assert_cmpuint(h2->b.start, <=, b->pos);
     g_assert_cmpuint(h2->a.start + 200, ==, h2->b.start);
-    // Is the 400 something to do with each random number being 2 frames
     g_assert_cmpuint(h2->a.end, ==, a->pos + 1);
     g_assert_cmpuint(h2->b.end, ==, b->pos + 1);
     g_assert_null(h2->next);


### PR DESCRIPTION
Fixes issue #18 by opening files in their 'natural mode' (e.g. float for floats, short for ints).

Would be nice to be better tested, but no point holding it up, I'll do some adiff tests in a different branch. 