### PR TITLE
Ui interaction

### DIFF
--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -205,7 +205,7 @@ class DiffApp:
 
     @property
     def _end_cue_mark(self):
-        if self._active_cue == 'stop':
+        if self._active_cue == 'end':
             return self._terminal.reverse(']')
         else:
             return ']'
@@ -267,13 +267,14 @@ class DiffApp:
         self._select_cue_helper('start')
 
     def _select_end_cue(self):
-        self._select_cue_helper('stop')
+        self._select_cue_helper('end')
 
     def _move_active_cue_point(self, d):
         if self._active_cue:
-            transform = self._get_frames_transform(self._draw_state.diff_width)
             attr_name = '_{}_cue'.format(self._active_cue)
-            setattr(self, attr_name, getattr(self, attr_name) + transform(d))
+            setattr(
+                self, attr_name,
+                getattr(self, attr_name) + self._draw_state.to_frames(d))
 
     def _on_left(self):
         self._move_active_cue_point(-1)

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -149,6 +149,7 @@ class DiffApp:
         self._start_cue = 0
         self._end_cue = 0
         self._active_cue = None
+        self._cursor = 0
 
         self._draw_state = None
 
@@ -234,6 +235,7 @@ class DiffApp:
             insertion_str[0] = self._insertion_fmt + insertion_str[0]
             insertion_str[-1] += self._common_fmt
             overlay_lists(diff_line, insertion_str, dl_start_idx)
+        overlay_lists(diff_line, '|', draw_state.to_chars(self._cursor))
         duration = draw_state.end_times[idx]
         return self._common_fmt(''.join(diff_line)) + ' ' + duration
 
@@ -309,17 +311,25 @@ class DiffApp:
         self._select_cue_helper('end')
 
     def _move_active_cue_point(self, d):
+        attr_name = '_{}_cue'.format(self._active_cue)
+        setattr(
+            self, attr_name,
+            getattr(self, attr_name) + self._draw_state.to_frames(d))
+
+    def _move_cursor(self, d):
+        self._cursor += self._draw_state.to_frames(d)
+
+    def _on_arrow(self, d):
         if self._active_cue:
-            attr_name = '_{}_cue'.format(self._active_cue)
-            setattr(
-                self, attr_name,
-                getattr(self, attr_name) + self._draw_state.to_frames(d))
+            self._move_active_cue_point(d)
+        else:
+            self._move_cursor(d)
 
     def _on_left(self):
-        self._move_active_cue_point(-1)
+        self._on_arrow(-1)
 
     def _on_right(self):
-        self._move_active_cue_point(1)
+        self._on_arrow(1)
 
 
 def diff(filename_a, filename_b):

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -168,6 +168,7 @@ class DiffApp:
         self._terminal = terminal or LinePrintingTerminal()
         self._insertion_fmt = self._terminal.green
         self._change_fmt = self._terminal.yellow
+        self._cursor_fmt = self._terminal.on_bright_black
         self._loop.add_reader(self._terminal.infile, self._handle_input)
         self._keyboard = Keyboard()
         self.bindings = {
@@ -261,7 +262,11 @@ class DiffApp:
 
     def _make_diff_lines(self, draw_state, diff):
         diff_reprs = self._make_diff_reprs(draw_state, diff)
-        diff_reprs.map(overlay_lists, '|', draw_state.to_chars(self._cursor))
+        cursor_pos = draw_state.to_chars(self._cursor)
+        existing_fmts = AB(self._terminal.normal)
+        existing_fmts += diff_reprs.get_format(cursor_pos)
+        diff_reprs.prepend_format_index(cursor_pos, self._cursor_fmt)
+        diff_reprs.post_format_index.distribute(AB(cursor_pos), existing_fmts)
         return diff_reprs.map(str) + AB(' ', ' ') + draw_state.end_times
 
     @property

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -79,7 +79,7 @@ def fmt_seconds(seconds):
 
 
 class DiffApp:
-    def __init__(self, filename_a, filename_b):
+    def __init__(self, filename_a, filename_b, terminal=None):
         self.filename_a = filename_a
         self.filename_b = filename_b
         self._psf_a = None
@@ -88,7 +88,7 @@ class DiffApp:
         self._len = None
 
         self._loop = asyncio.get_event_loop()
-        self._terminal = LinePrintingTerminal()
+        self._terminal = terminal or LinePrintingTerminal()
         self._common_fmt = self._terminal.yellow
         self._insertion_fmt = self._terminal.green
         self._loop.add_reader(self._terminal.infile, self._handle_input)
@@ -146,7 +146,6 @@ class DiffApp:
         '''
         a_offset = 0
         b_offset = 0
-        # FIXME: is there a way to do this without an intermediate list?
         result = []
         for hunk in diff:
             result.append(Hunk(

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -39,7 +39,7 @@ class Hunk:
     def __eq__(self, other):
         return all(
             getattr(self, name) == getattr(other, name) for name in
-            self.__slots__)
+            self.__slots__ if not name.startswith('_'))
 
     def __iter__(self):
         return chain(*zip(self.starts, self.ends))

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -187,9 +187,7 @@ class DiffApp:
     def _run(self):
         diff = yield from self._do_diff()
         self._diff = tuple(NormalisedHunk.process_diff(diff))
-        self._len = max(
-            self._psfs.a.frames() + self._diff[-1].offsets.a,
-            self._psfs.b.frames() + self._diff[-1].offsets.b)
+        self._len = max(self._psfs.frames() + self._diff[-1].offsets)
         self._cue_next_hunk()
         self._draw()
         while True:

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -169,6 +169,7 @@ class DiffApp:
             ']': self._select_end_cue,
             'left': self._on_left,
             'right': self._on_right,
+            'esc': self._on_esc,
         }
 
     _zoom = Clamped(1.0, None)
@@ -341,6 +342,12 @@ class DiffApp:
 
     def _on_right(self):
         self._on_arrow(1)
+
+    def _on_esc(self):
+        if self._active_cue:
+            self._active_cue = None
+        else:
+            self._cursor = self._start_cue
 
 
 def diff(filename_a, filename_b):

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -150,6 +150,7 @@ class DiffApp:
         self._end_cue = 0
         self._active_cue = None
         self._cursor = 0
+        self._status = ''
 
         self._draw_state = None
 
@@ -200,6 +201,7 @@ class DiffApp:
 
     def _handle_input(self):
         key = self._keyboard[self._terminal.infile.read()]
+        self._status = key
         action = self.bindings.get(key, lambda: None)
         action()
         self._draw()
@@ -284,7 +286,8 @@ class DiffApp:
         lines = [
             self._make_diff_line(ds, self._diff, 0),
             self._make_cue_line(ds),
-            self._make_diff_line(ds, self._diff, 1)
+            self._make_diff_line(ds, self._diff, 1),
+            self._status.ljust(self._terminal.width)
         ]
         self._terminal.print_lines(lines)
 

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -46,7 +46,7 @@ class Hunk:
 
 
 class NormalisedHunk(Hunk):
-    __slots__ = Hunk.__slots__ + ('offsets',)
+    __slots__ = Hunk.__slots__ + ('offsets', '_end')
 
     def __init__(self, start_a, end_a, start_b, end_b, offset_a, offset_b):
         super().__init__(start_a, end_a, start_b, end_b)
@@ -84,6 +84,7 @@ class NormalisedHunk(Hunk):
         return self.starts.a
 
     @property
+    @cache
     def end(self):
         return max(self.ends)
 
@@ -112,7 +113,8 @@ class _DrawState:
         self.start_times = None
         self.end_times = None
 
-    @caching_property
+    @property
+    @cache
     def diff_width(self):
         if self.start_times:
             start_time_width = max(map(len, self.start_times)) + 1
@@ -121,7 +123,8 @@ class _DrawState:
         end_time_width = max(map(len, self.end_times)) + 1
         return self.app._terminal.width - start_time_width - end_time_width
 
-    @caching_property
+    @property
+    @cache
     def chars_per_frame(self):
         return self.app._zoom * self.diff_width / self.app._len
 

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -220,11 +220,6 @@ class DiffApp:
             draw_state.to_chars(self._end_cue))
         return ''.join(cue_line)
 
-    @property
-    def _diff_width(self):
-        if self._zoom > 1:
-            pass
-
     def _draw(self):
         self._draw_state = ds = _DrawState(self)
         ds.end_times = AB(*map(fmt_seconds, map(duration, self._psfs)))

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -9,7 +9,7 @@ from itertools import chain
 import pysndfile
 
 from terminal import LinePrintingTerminal, Keyboard
-from util import caching_property, overlay_lists, AB, Time
+from util import caching_property, overlay_lists, AB, Time, Clamped
 
 bdiff_frames_path = os.path.join(
     os.path.dirname(__file__), os.pardir, 'diff_frames')
@@ -143,7 +143,7 @@ class DiffApp:
         self._psfs = None
         self._durations = None
         self._diff = None
-        self._len = None
+        self._len = 0
 
         self._zoom = 1.0
         self._start_cue = 0
@@ -170,6 +170,9 @@ class DiffApp:
             'left': self._on_left,
             'right': self._on_right,
         }
+
+    _zoom = Clamped(1.0, None)
+    _cursor = Clamped(0, lambda self: self._len)
 
     def __call__(self):
         self._psfs = AB.from_map(pysndfile.PySndfile, self.filenames)
@@ -286,7 +289,7 @@ class DiffApp:
         self._zoom *= 1.1
 
     def _zoom_out(self):
-        self._zoom = max(1.0, self._zoom / 1.1)
+        self._zoom /= 1.1
 
     def _cue_hunk_helper(self, iterable, predicate):
         self._active_cue = None

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -4,6 +4,7 @@ import sys
 import argh
 import asyncio
 import subprocess
+from itertools import chain
 
 import pysndfile
 
@@ -25,6 +26,9 @@ class Hunk:
         return all(
             getattr(self, name) == getattr(other, name) for name in
             self.__slots__)
+
+    def __iter__(self):
+        return chain(*zip(self.starts, self.ends))
 
 
 class NormalisedHunk(Hunk):

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -4,11 +4,11 @@ import sys
 import argh
 import asyncio
 import subprocess
-from functools import wraps
 
 import pysndfile
 
 from terminal import LinePrintingTerminal, Keyboard
+from util import caching_property, fmt_seconds, overlay_lists
 
 bdiff_frames_path = os.path.join(
     os.path.dirname(__file__), os.pardir, 'diff_frames')
@@ -49,83 +49,6 @@ def duration(sndfile):
     :returns float: the duration of the given audio file, in seconds.
     '''
     return sndfile.frames() / sndfile.samplerate()
-
-
-class Time:
-    '''Formats the given time in seconds to an appropriate prescision exlcuding
-    leading zero components. Edge cases around overflowing make this
-    non-trivial.
-    '''
-
-    __slots__ = 'hours', 'minutes', 'seconds'
-
-    def __init__(self, seconds):
-        self.hours, self.minutes, self.seconds = self._round_hms(
-            *self._split(seconds))
-
-    @staticmethod
-    def _split(seconds):
-        hours, remainder = divmod(seconds, 3600)
-        minutes, seconds = divmod(remainder, 60)
-        return hours, minutes, seconds
-
-    @staticmethod
-    def _round_pair(big, small, precision):
-        if round(small, precision) == 60:
-            big += 1
-            small = 0.0
-        return big, small
-
-    @staticmethod
-    def _select(hours, minutes, seconds, a, b, c):
-        if not hours:
-            if not minutes:
-                return c
-            return b
-        return a
-
-    def _round_hms(self, hours, minutes, seconds):
-        second_prec = self._select(hours, minutes, seconds, 0, 1, 2)
-        minutes, seconds = self._round_pair(minutes, seconds, second_prec)
-        hours, minutes = self._round_pair(hours, minutes, 0)
-        return hours, minutes, seconds
-
-    def __str__(self):
-        fmt_str = self._select(
-            self.hours, self.minutes, self.seconds,
-            '{hours:.0f}:{minutes:02.0f}:{seconds:02.0f}',
-            '{minutes:.0f}:{seconds:04.1f}',
-            '{seconds:.2f}')
-        return fmt_str.format(
-            hours=self.hours, minutes=self.minutes, seconds=self.seconds)
-
-
-def fmt_seconds(seconds):
-    return str(Time(seconds))
-
-
-def overlay_lists(base, new, offset):
-    '''Mutates the given base list by overlaying the new list on top at a given
-    offset.
-    '''
-    if offset + len(new) >= 0:
-        for i in range(len(new)):
-            base_idx = i + offset
-            if 0 <= base_idx < len(base):
-                base[base_idx] = new[i]
-            elif base_idx >= len(base):
-                break
-
-
-def caching_property(method):
-    attr_name = '_' + method.__name__
-    @property
-    @wraps(method)
-    def new_property(self):
-        if not getattr(self, attr_name):
-            setattr(self, attr_name, method(self))
-        return getattr(self, attr_name)
-    return new_property
 
 
 class _DrawState:

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -228,13 +228,13 @@ class DiffApp:
         diff_repr = ['-'] * draw_state.diff_width
         for hunk in diff:
             hunk_num_chars = draw_state.to_chars(len(hunk))
-            dl_start_idx = draw_state.to_chars(hunk.start)
-            dl_end_idx = dl_start_idx + hunk_num_chars
+            dr_start_idx = draw_state.to_chars(hunk.start)
+            dr_end_idx = dr_start_idx + hunk_num_chars
 
             # hunk is entirely out of viewport, so don't bother drawing
-            if dl_end_idx < 0:
+            if dr_end_idx < 0:
                 continue
-            elif dl_start_idx > len(diff_repr):
+            elif dr_start_idx > len(diff_repr):
                 break
 
             frames_inserted = hunk.ends[idx] - hunk.starts[idx]
@@ -247,7 +247,7 @@ class DiffApp:
                 fmt = self._change_fmt
             insertion_str[0] = fmt + insertion_str[0]
             insertion_str[-1] += self._terminal.normal
-            overlay_lists(diff_repr, insertion_str, dl_start_idx)
+            overlay_lists(diff_repr, insertion_str, dr_start_idx)
         return diff_repr
 
     def _make_diff_line(self, draw_state, diff, idx):

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -190,8 +190,7 @@ class DiffApp:
 
     def __call__(self):
         self._psfs = AB.from_map(pysndfile.PySndfile, self.filenames)
-        self._durations = AB.from_map(duration, self._psfs)
-        self._durations = AB.from_map(Time.from_seconds, self._durations)
+        self._durations = self._psfs.map(duration).map(Time.from_seconds)
         with self._terminal.unbuffered_input(), (
                 self._terminal.nonblocking_input()), (
                 self._terminal.hidden_cursor()):
@@ -291,7 +290,7 @@ class DiffApp:
 
     def _draw(self):
         self._draw_state = ds = _DrawState(self)
-        ds.end_times = AB.from_map(str, self._durations)
+        ds.end_times = self._durations.map(str)
         diff_lines = self._make_diff_lines(ds, self._diff)
         if self._zoom == 1:
             pass

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -137,7 +137,7 @@ class _DrawState:
 
     def to_chars(self, frames):
         '''Transforms a point in the space of the "virtual" diff space, given in
-        frames, into a x-coordintate on the terminal, taking into account
+        frames, into a x-coordinate on the terminal, taking into account
         various application state parameters.
         '''
         return int(self.chars_per_frame * frames)

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -305,6 +305,7 @@ class DiffApp:
             if predicate(hunk):
                 self._start_cue = hunk.start
                 self._end_cue = hunk.end
+                self._cursor = self._start_cue
                 break
 
     def _cue_next_hunk(self):

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -19,8 +19,21 @@ class Hunk:
     __slots__ = 'starts', 'ends'
 
     def __init__(self, start_a, end_a, start_b, end_b):
+        '''
+        :parameter start_a: The frame in A where the files start to differ.
+        :parameter end_a: The frame in A after which the files cease to differ.
+        :parameter start_b: The frame in B where the files start to differ.
+        :parameter end_b: The frame in B after which the file cease to differ.
+        '''
         self.starts = AB(start_a, start_b)
         self.ends = AB(end_a, end_b)
+
+    def _get_attr_string(self):
+        return 'start_a={}, end_a={}, start_b={}, end_b={}'.format(*self)
+
+    def __repr__(self):
+        return '{}({})'.format(
+            self.__class__.__name__, self._get_attr_string())
 
     def __eq__(self, other):
         return all(

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -56,13 +56,11 @@ class _DrawState:
     call.
     '''
     __slots__ = (
-        'app', '_diff_width', '_chars_per_frame', 'start_time_a', 'end_time_a',
-        'start_time_b', 'end_time_b')
+        'app', '_diff_width', '_chars_per_frame', 'start_time_a',
+        'end_time_a', 'start_time_b', 'end_time_b')
 
     def __init__(self, app):
         self.app = app
-        self._diff_width = None
-        self._chars_per_frame = None
 
     @caching_property
     def diff_width(self):

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -327,11 +327,11 @@ class DiffApp:
 
     def _cue_next_hunk(self):
         self._cue_hunk_helper(
-            self._diff, lambda hunk: hunk.start > self._start_cue)
+            self._diff, lambda hunk: hunk.start > self._cursor)
 
     def _cue_prev_hunk(self):
         self._cue_hunk_helper(
-            reversed(self._diff), lambda hunk: hunk.end < self._end_cue)
+            reversed(self._diff), lambda hunk: hunk.end < self._cursor)
 
     def _select_cue_helper(self, cue_name):
         if self._active_cue == cue_name:

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -274,9 +274,11 @@ class DiffApp:
 
     def _draw(self):
         self._draw_state = ds = _DrawState(self)
+        ds.end_times = AB.from_map(str, self._durations)
         if self._zoom == 1:
-            ds.end_times = AB.from_map(str, self._durations)
+            pass
         else:
+            # FIXME: Show times of each end when zoomed in
             pass
         lines = [
             self._make_diff_line(ds, self._diff, 0),

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -108,7 +108,11 @@ class DiffApp:
         self._insertion_fmt = self._terminal.green
         self._loop.add_reader(self._terminal.infile, self._handle_input)
         self._keyboard = Keyboard()
-        self.bindings = {}
+        self.bindings = {
+            '+': self._zoom_in,
+            '=': self._zoom_in,
+            '-': self._zoom_out,
+        }
 
     def __call__(self):
         self._psf_a = pysndfile.PySndfile(self.filename_a)
@@ -191,7 +195,7 @@ class DiffApp:
             dl_start_idx = transform(hunk.start_a)  # Identical for .start_b
             dl_end_idx = dl_start_idx + hunk_num_chars
 
-            # hunk is entirely out of viewport:
+            # hunk is entirely out of viewport, so don't bother drawing
             if dl_end_idx < 0:
                 continue
             elif dl_start_idx > len(diff_line):
@@ -223,6 +227,12 @@ class DiffApp:
             duration_b
         ]
         self._terminal.print_lines(lines)
+
+    def _zoom_in(self):
+        self._zoom *= 1.1
+
+    def _zoom_out(self):
+        self._zoom = max(1.0, self._zoom / 1.1)
 
 
 def diff(filename_a, filename_b):

--- a/python/diff_frames.py
+++ b/python/diff_frames.py
@@ -171,6 +171,8 @@ class DiffApp:
             'left': self._on_left,
             'right': self._on_right,
             'esc': self._on_esc,
+            'home': self._on_home,
+            'end': self._on_end,
         }
 
     _zoom = Clamped(1.0, None)
@@ -345,6 +347,18 @@ class DiffApp:
 
     def _on_right(self):
         self._on_arrow(1)
+
+    def _on_home(self):
+        if self._cursor == self._start_cue:
+            self._cursor = 0
+        else:
+            self._cursor = self._start_cue
+
+    def _on_end(self):
+        if self._cursor == self._end_cue:
+            self._cursor = self._len
+        else:
+            self._cursor = self._end_cue
 
     def _on_esc(self):
         if self._active_cue:

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -2,10 +2,14 @@ from unittest import TestCase
 from mock import Mock
 
 from pysndfile import PySndfile
-from diff_frames import fmt_seconds, duration
+from terminal import LinePrintingTerminal
+from diff_frames import fmt_seconds, duration, DiffApp, Hunk
 
 
 class TestDiffFrames(TestCase):
+    def setUp(self):
+        self.app = DiffApp('some_a', 'some_b')
+
     def test_duration(self):
         mock_snd_file = Mock(spec=PySndfile)
         mock_snd_file.frames.return_value = 44100 * 42 + 441
@@ -19,3 +23,22 @@ class TestDiffFrames(TestCase):
         self.assertEqual(fmt_seconds(61.789), '1:01.8')
         self.assertEqual(fmt_seconds(3599.99), '1:00:00')
         self.assertEqual(fmt_seconds(3601.5), '1:00:02')
+
+
+    unprocessed_diff = (
+        Hunk(0, 0, 0, 1000),
+        Hunk(2000, 5000, 3000, 7000),
+        Hunk(6000, 7000, 8000, 8000),
+    )
+
+    processed_diff = (
+        Hunk(0, 0, 0, 1000),
+        Hunk(3000, 6000, 3000, 7000),
+        Hunk(11000, 12000, 11000, 11000),
+    )
+
+    def test_process_diff(self):
+        self.assertEqual(
+            self.app._process_diff(self.unprocessed_diff),
+            (self.processed_diff, 4000, 5000))
+

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -43,10 +43,11 @@ class TestDiffFrames(TestCase):
             (self.processed_diff, 4000, 5000))
 
     def _diff_line_helper(self, app, expected_a, expected_b):
-        result = app._make_diff_line(self.processed_diff, 12000, 50)
+        app._len = 12000
+        result = app._make_diff_line(self.processed_diff, 50)
         self.assertEqual(repr(result), repr(expected_a))
         result = app._make_diff_line(
-            self.processed_diff, 12000, 50, is_b=True)
+            self.processed_diff, 50, is_b=True)
         self.assertEqual(repr(result), repr(expected_b))
 
     def test_make_diff_line_plain(self):

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -3,7 +3,19 @@ from mock import Mock
 
 from pysndfile import PySndfile
 from terminal import LinePrintingTerminal
-from diff_frames import fmt_seconds, duration, DiffApp, Hunk, overlay_lists
+from diff_frames import (
+    fmt_seconds, duration, DiffApp, Hunk, NormalisedHunk, overlay_lists)
+
+
+class TestHunk(TestCase):
+    def test_eq(self):
+        self.assertEqual(Hunk(1, 2, 3, 4), Hunk(1, 2, 3, 4))
+        self.assertNotEqual(Hunk(1, 2, 3, 4), Hunk(5, 6, 7, 8))
+
+
+class TestNormalisedHunk(TestCase):
+    def test_len(self):
+        self.assertEqual(len(NormalisedHunk(1, 5, 1, 10)), 9)
 
 
 class TestDiffFrames(TestCase):
@@ -48,9 +60,9 @@ class TestDiffFrames(TestCase):
     )
 
     processed_diff = (
-        Hunk(0, 0, 0, 1000),
-        Hunk(3000, 6000, 3000, 7000),
-        Hunk(11000, 12000, 11000, 11000),
+        NormalisedHunk(0, 0, 0, 1000),
+        NormalisedHunk(3000, 6000, 3000, 7000),
+        NormalisedHunk(11000, 12000, 11000, 11000),
     )
     diff_line_a = '    --------++++++++++++    ----------------++++'
     diff_line_b = '++++--------++++++++++++++++----------------    '

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -2,6 +2,8 @@ from unittest import TestCase
 from mock import Mock, patch
 
 from pysndfile import PySndfile
+
+from util import AB
 from terminal import LinePrintingTerminal
 from diff_frames import duration, DiffApp, Hunk, NormalisedHunk, _DrawState
 
@@ -40,54 +42,47 @@ class TestDiffFrames(TestCase):
         NormalisedHunk(3000, 6000, 3000, 7000),
         NormalisedHunk(11000, 12000, 11000, 11000),
     )
-    diff_line_a = '    --------++++++++++++    ----------------++++'
-    diff_line_b = '++++--------++++++++++++++++----------------    '
+    diff_lines = AB(
+        '    --------++++++++++++    ----------------++++',
+        '++++--------++++++++++++++++----------------    ')
 
     def test_process_diff(self):
         self.assertEqual(
             self.app._process_diff(self.unprocessed_diff),
-            (self.processed_diff, 4000, 5000))
+            (self.processed_diff, (4000, 5000)))
 
-    def _diff_line_helper(self, app, expected_a, expected_b):
+    def _diff_line_helper(self, app, expecteds):
         app._len = 12000  # each 1000 frames is 4 characters at 48 width
         draw_state = _DrawState(app)
-        draw_state.end_time_a = 'woo'
-        expected_a += ' woo'
-        draw_state.end_time_b = 'waa'
-        expected_b += ' waa'
+        draw_state.end_times = AB('woo', 'waa')
+        expecteds += AB(' woo', ' waa')
         with patch.object(_DrawState, 'diff_width', 48):
-            result = app._make_diff_line(draw_state, self.processed_diff)
-            self.assertEqual(repr(result), repr(expected_a))
-            result = app._make_diff_line(
-                draw_state, self.processed_diff, is_b=True)
-            self.assertEqual(repr(result), repr(expected_b))
+            for i, expected in enumerate(expecteds):
+                result = app._make_diff_line(
+                    draw_state, self.processed_diff, i)
+                self.assertEqual(repr(result), repr(expected))
 
     def test_make_diff_line_plain(self):
-        self._diff_line_helper(
-            self.app, expected_a=self.diff_line_a, expected_b=self.diff_line_b)
+        self._diff_line_helper(self.app, self.diff_lines)
 
     def test_make_diff_line_colour(self):
         app = DiffApp('some_a', 'some_b')
         ins = app._insertion_fmt
         com = app._common_fmt
-        self._diff_line_helper(
-            app,
-            expected_a=com(
-                '{ins}    {com}--------{ins}++++++++++++    {com}-------------'
+        expecteds = AB(
+            com('{ins}    {com}--------{ins}++++++++++++    {com}-------------'
                 '---{ins}++++{com}').format(ins=ins, com=com),
-            expected_b=com(
-                '{ins}++++{com}--------{ins}++++++++++++++++{com}-------------'
+            com('{ins}++++{com}--------{ins}++++++++++++++++{com}-------------'
                 '---{ins}    {com}').format(ins=ins, com=com))
+        self._diff_line_helper(app, expecteds)
 
-    def multiply_up(self, string, multiplier):
-        return ''.join(c * multiplier for c in string)
+    def _multiply_up(self, string):
+        return ''.join(c * 2 for c in string)[:48]
 
     def test_make_diff_line_zoom(self):
         self.app._zoom = 2.0
         self._diff_line_helper(
-            self.app,
-            expected_a=self.multiply_up(self.diff_line_a, 2)[:48],
-            expected_b=self.multiply_up(self.diff_line_b, 2)[:48])
+            self.app, AB(*map(self._multiply_up, self.diff_lines)))
 
     def test_zoom(self):
         self.app._zoom_in()

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -63,10 +63,15 @@ class TestDiffFrames(TestCase):
                 self.assertEqual(repr(result), repr(expected))
 
     def test_make_diff_line_plain(self):
-        self._diff_line_helper(self.app, self.diff_lines)
+        # FIXME: hack whilst showing cursor:
+        def hack(expected):
+            return '|' + expected[1:]
+        self._diff_line_helper(self.app, AB.from_map(hack, self.diff_lines))
 
     def test_make_diff_line_colour(self):
         app = DiffApp('some_a', 'some_b')
+        # FIXME: hack whilst showing cursor:
+        app._cursor = -1000
         ins = app._insertion_fmt
         com = app._common_fmt
         expecteds = AB(
@@ -81,6 +86,8 @@ class TestDiffFrames(TestCase):
 
     def test_make_diff_line_zoom(self):
         self.app._zoom = 2.0
+        # FIXME: hack whilst showing cursor:
+        self.app._cursor = -1000
         self._diff_line_helper(
             self.app, AB(*map(self._multiply_up, self.diff_lines)))
 

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -55,9 +55,9 @@ class TestDiffFrames(TestCase):
         app._len = 12000  # each 1000 frames is 4 characters at 48 width
         draw_state = _DrawState(app)
         with patch.object(_DrawState, 'diff_width', 48):
-            for i, expected in enumerate(expecteds):
-                result = ''.join(app._make_diff_repr(
-                    draw_state, self.processed_diff, i))
+            results = app._make_diff_reprs(draw_state, self.processed_diff)
+            results = results.map(str)
+            for result, expected in zip(results, expecteds):
                 self.assertEqual(repr(result), repr(expected))
 
     def test_make_diff_repr_plain(self):

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -54,24 +54,17 @@ class TestDiffFrames(TestCase):
     def _diff_line_helper(self, app, expecteds):
         app._len = 12000  # each 1000 frames is 4 characters at 48 width
         draw_state = _DrawState(app)
-        draw_state.end_times = AB('woo', 'waa')
-        expecteds += AB(' woo', ' waa')
         with patch.object(_DrawState, 'diff_width', 48):
             for i, expected in enumerate(expecteds):
-                result = app._make_diff_line(
-                    draw_state, self.processed_diff, i)
+                result = ''.join(app._make_diff_repr(
+                    draw_state, self.processed_diff, i))
                 self.assertEqual(repr(result), repr(expected))
 
-    def test_make_diff_line_plain(self):
-        # FIXME: hack whilst showing cursor:
-        def hack(expected):
-            return '|' + expected[1:]
-        self._diff_line_helper(self.app, AB.from_map(hack, self.diff_lines))
+    def test_make_diff_repr_plain(self):
+        self._diff_line_helper(self.app, self.diff_lines)
 
     def test_make_diff_line_colour(self):
         app = DiffApp('some_a', 'some_b')
-        # FIXME: hack whilst showing cursor:
-        app._cursor = -1000
         ins = app._insertion_fmt
         com = app._common_fmt
         expecteds = AB(
@@ -86,8 +79,6 @@ class TestDiffFrames(TestCase):
 
     def test_make_diff_line_zoom(self):
         self.app._zoom = 2.0
-        # FIXME: hack whilst showing cursor:
-        self.app._cursor = -1000
         self._diff_line_helper(
             self.app, AB(*map(self._multiply_up, self.diff_lines)))
 

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -30,29 +30,6 @@ class TestDiffFrames(TestCase):
         mock_snd_file.samplerate.return_value = 44100
         self.assertEqual(duration(mock_snd_file), 42.01)
 
-    def test_fmt_seconds(self):
-        self.assertEqual(fmt_seconds(1.567), '1.57')
-        self.assertEqual(fmt_seconds(59.899), '59.90')
-        self.assertEqual(fmt_seconds(59.999), '1:00.0')
-        self.assertEqual(fmt_seconds(61.789), '1:01.8')
-        self.assertEqual(fmt_seconds(3599.99), '1:00:00')
-        self.assertEqual(fmt_seconds(3601.5), '1:00:02')
-
-    def test_overlay_lists(self):
-        data = (
-            (0, ('---', '+--', '++-', '+++', '+++')),
-            (1, ('---', '-+-', '-++', '-++', '-++')),
-            (5, ('---', '---', '---', '---', '---')),
-            (-1, ('---', '---', '+--', '++-', '+++')),
-            (-4, ('---', '---', '---', '---', '---')),
-        )
-        for offset, expecteds in data:
-            for i, expected in enumerate(expecteds):
-                base = ['-'] * 3
-                new = ['+'] * i
-                overlay_lists(base, new, offset)
-                self.assertEqual(base, list(expected))
-
     unprocessed_diff = (
         Hunk(0, 0, 0, 1000),
         Hunk(2000, 5000, 3000, 7000),

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -42,3 +42,30 @@ class TestDiffFrames(TestCase):
             self.app._process_diff(self.unprocessed_diff),
             (self.processed_diff, 4000, 5000))
 
+    def _diff_line_helper(self, app, expected_a, expected_b):
+        result = app._make_diff_line(self.processed_diff, 12000, 50)
+        self.assertEqual(repr(result), repr(expected_a))
+        result = app._make_diff_line(
+            self.processed_diff, 12000, 50, is_b=True)
+        self.assertEqual(repr(result), repr(expected_b))
+
+    def test_make_diff_line_plain(self):
+        app = DiffApp(
+            'some_a', 'some_b',
+            terminal=LinePrintingTerminal(force_styling=None))
+        self._diff_line_helper(
+            app,
+            expected_a='     -------++++++++++++     ----------------+++++',
+            expected_b='+++++-------+++++++++++++++++----------------     ')
+
+    def test_make_diff_line_colour(self):
+        ins = self.app._insertion_fmt
+        com = self.app._common_fmt
+        self._diff_line_helper(
+            self.app,
+            expected_a=com(
+                '{ins}     {com}-------{ins}++++++++++++     {com}-------------'
+                '---{ins}+++++{com}').format(ins=ins, com=com),
+            expected_b=com(
+                '{ins}+++++{com}-------{ins}+++++++++++++++++{com}-------------'
+                '---{ins}     {com}').format(ins=ins, com=com))

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -1,8 +1,17 @@
 from unittest import TestCase
-from diff_frames import fmt_seconds
+from mock import Mock
+
+from pysndfile import PySndfile
+from diff_frames import fmt_seconds, duration
 
 
 class TestDiffFrames(TestCase):
+    def test_duration(self):
+        mock_snd_file = Mock(spec=PySndfile)
+        mock_snd_file.frames.return_value = 44100 * 42 + 441
+        mock_snd_file.samplerate.return_value = 44100
+        self.assertEqual(duration(mock_snd_file), 42.01)
+
     def test_fmt_seconds(self):
         self.assertEqual(fmt_seconds(1.567), '1.57')
         self.assertEqual(fmt_seconds(59.899), '59.90')

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+from diff_frames import fmt_seconds
+
+
+class TestDiffFrames(TestCase):
+    def test_fmt_seconds(self):
+        self.assertEqual(fmt_seconds(1.567), '1.57')
+        self.assertEqual(fmt_seconds(59.899), '59.90')
+        self.assertEqual(fmt_seconds(59.999), '1:00.0')
+        self.assertEqual(fmt_seconds(61.789), '1:01.8')
+        self.assertEqual(fmt_seconds(3599.99), '1:00:00')
+        self.assertEqual(fmt_seconds(3601.5), '1:00:02')

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -64,14 +64,17 @@ class TestDiffFrames(TestCase):
         self._diff_line_helper(self.app, self.diff_lines)
 
     def test_make_diff_line_colour(self):
-        app = DiffApp('some_a', 'some_b')
+        app = DiffApp(
+            'some_a', 'some_b',
+            terminal=LinePrintingTerminal(force_styling=True))
         ins = app._insertion_fmt
-        com = app._common_fmt
+        chg = app._change_fmt
+        com = app._terminal.normal
         expecteds = AB(
-            com('{ins}    {com}--------{ins}++++++++++++    {com}-------------'
-                '---{ins}++++{com}').format(ins=ins, com=com),
-            com('{ins}++++{com}--------{ins}++++++++++++++++{com}-------------'
-                '---{ins}    {com}').format(ins=ins, com=com))
+            ('{ins}    {com}--------{chg}++++++++++++{ins}    {com}--------'
+             '--------{ins}++++{com}'.format(ins=ins, com=com, chg=chg)),
+            ('{ins}++++{com}--------{chg}++++++++++++{ins}++++{com}--------'
+             '--------{ins}    {com}'.format(ins=ins, com=com, chg=chg)))
         self._diff_line_helper(app, expecteds)
 
     def _multiply_up(self, string):

--- a/python/test_diff_frames.py
+++ b/python/test_diff_frames.py
@@ -16,7 +16,7 @@ class TestHunk(TestCase):
 
 class TestNormalisedHunk(TestCase):
     def test_len(self):
-        self.assertEqual(len(NormalisedHunk(1, 5, 1, 10)), 9)
+        self.assertEqual(len(NormalisedHunk(1, 5, 1, 10, 0, 0)), 9)
 
 
 class TestDiffFrames(TestCase):
@@ -38,18 +38,18 @@ class TestDiffFrames(TestCase):
     )
 
     processed_diff = (
-        NormalisedHunk(0, 0, 0, 1000),
-        NormalisedHunk(3000, 6000, 3000, 7000),
-        NormalisedHunk(11000, 12000, 11000, 11000),
+        NormalisedHunk(0, 0, 0, 1000, 0, 0),
+        NormalisedHunk(3000, 6000, 3000, 7000, 1000, 0),
+        NormalisedHunk(11000, 12000, 11000, 11000, 5000, 3000),
     )
     diff_lines = AB(
         '    --------++++++++++++    ----------------++++',
         '++++--------++++++++++++++++----------------    ')
 
-    def test_process_diff(self):
-        self.assertEqual(
-            self.app._process_diff(self.unprocessed_diff),
-            (self.processed_diff, (4000, 5000)))
+    def test_normalise_diff(self):
+        normalised_diff = tuple(
+            NormalisedHunk.process_diff(self.unprocessed_diff))
+        self.assertEqual(normalised_diff, self.processed_diff)
 
     def _diff_line_helper(self, app, expecteds):
         app._len = 12000  # each 1000 frames is 4 characters at 48 width

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+
+from util import fmt_seconds, overlay_lists
+
+
+class TestUtil(TestCase):
+    def test_fmt_seconds(self):
+        self.assertEqual(fmt_seconds(1.567), '1.57')
+        self.assertEqual(fmt_seconds(59.899), '59.90')
+        self.assertEqual(fmt_seconds(59.999), '1:00.0')
+        self.assertEqual(fmt_seconds(61.789), '1:01.8')
+        self.assertEqual(fmt_seconds(3599.99), '1:00:00')
+        self.assertEqual(fmt_seconds(3601.5), '1:00:02')
+
+    def test_overlay_lists(self):
+        data = (
+            (0, ('---', '+--', '++-', '+++', '+++')),
+            (1, ('---', '-+-', '-++', '-++', '-++')),
+            (5, ('---', '---', '---', '---', '---')),
+            (-1, ('---', '---', '+--', '++-', '+++')),
+            (-4, ('---', '---', '---', '---', '---')),
+        )
+        for offset, expecteds in data:
+            for i, expected in enumerate(expecteds):
+                base = ['-'] * 3
+                new = ['+'] * i
+                overlay_lists(base, new, offset)
+                self.assertEqual(base, list(expected))

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -195,6 +195,13 @@ class TestCharList(TestCase):
         self.l.append_format_index(5, ']')
         self.assertEqual(str(self.l), 'hel {l[[o ]]w} orld')
 
+    def test_get_format(self):
+        self.assertEqual(self.l.get_format(3), '')
+        self.l.pre_format_index(1, '[')
+        self.assertEqual(self.l.get_format(3), '[')
+        self.l.post_format_index(1, ']')
+        self.assertEqual(self.l.get_format(3), ']')
+
     def test_overlay_char_lists(self):
         new_1 = CharList('bob')
         new_1.pre_format_index(1, '[')

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from util import fmt_seconds, overlay_lists
+from util import fmt_seconds, overlay_lists, caching_property
 
 
 class TestUtil(TestCase):
@@ -26,3 +26,25 @@ class TestUtil(TestCase):
                 new = ['+'] * i
                 overlay_lists(base, new, offset)
                 self.assertEqual(base, list(expected))
+
+    def test_caching_property(self):
+        self.computed = 0
+        class Foo:
+            def __init__(self, return_value):
+                self.return_value = return_value
+
+            @caching_property
+            def something(instance):
+                self.computed += 1
+                return instance.return_value
+
+        f1 = Foo('bananas')
+        self.assertEqual(f1.something, 'bananas')
+        self.assertEqual(self.computed, 1)
+        self.assertEqual(f1.something, 'bananas')
+        self.assertEqual(self.computed, 1)
+        f2 = Foo('')
+        self.assertEqual(f2.something, '')
+        self.assertEqual(self.computed, 2)
+        self.assertEqual(f2.something, '')
+        self.assertEqual(self.computed, 2)

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -78,7 +78,11 @@ class TestAB(TestCase):
         self.assertEqual(AB(1, 2), (1, 2))
         self.assertNotEqual(AB(1, 2), AB(3, 4))
         self.assertNotEqual(AB(1, 2), (1, 2, 3))
+
+    def test_add(self):
         self.assertEqual(AB(1, 2) + AB(3, 2), AB(4, 4))
+
+    def test_sub(self):
         self.assertEqual(AB(1, 2) - AB(3, 2), AB(-2, 0))
 
     def test_get_set_item(self):

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -69,6 +69,10 @@ class TestUtil(TestCase):
 
 
 class TestAB(TestCase):
+    def test_variable_constructor(self):
+        self.assertEqual(AB(1), AB(1, 1))
+        self.assertRaises(TypeError, AB, 1, 2, 3)
+
     def test_eq(self):
         self.assertEqual(AB(1, 2), AB(1, 2))
         self.assertEqual(AB(1, 2), (1, 2))

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -107,7 +107,6 @@ class TestAB(TestCase):
 
     def test_attr_lookup_and_call(self):
         ab = AB('hello', 'world')
-        print(ab.index)
         self.assertEqual(ab.index('l'), AB(2, 3))
 
 

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -109,6 +109,13 @@ class TestAB(TestCase):
         ab = AB('hello', 'world')
         self.assertEqual(ab.index('l'), AB(2, 3))
 
+    def test_distribute(self):
+        f = lambda x, y: x + y
+        ab = AB(f, f)
+        cd = AB('c', 'd')
+        ef = AB('e', 'f')
+        self.assertEqual(ab.distribute(cd, ef), AB('ce', 'df'))
+
 
 class TestClamped(TestCase):
     def setUp(self):

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-from util import overlay_lists, caching_property, AB, Time, Clamped
+from util import (
+    overlay_lists, cache, AB, Time, Clamped, FormattedChar, CharList)
 
 
 class TestUtil(TestCase):
@@ -157,3 +158,33 @@ class TestClamped(TestCase):
         check(None, None, -2, 0, 2)
         check(None, 1, -2, 0, 1)
         check(-1, None, -1, 0, 2)
+
+
+class TestFormattedChar(TestCase):
+    def test_str(self):
+        f = FormattedChar('c', 'pre:', ':post')
+        self.assertEqual(str(f), 'pre:c:post')
+
+
+class TestCharList(TestCase):
+    def setUp(self):
+        self.l = CharList('hello world')
+
+    def test_str(self):
+        self.assertEqual(str(self.l), 'hello world')
+
+    def test_format_index(self):
+        self.l.pre_format_index(4, '[')
+        self.l.post_format_index(5, ']')
+        self.assertEqual(str(self.l), 'hell[o ]world')
+
+    def test_overlay_char_lists(self):
+        new_1 = CharList('bob')
+        new_1.pre_format_index(1, '[')
+        new_1.post_format_index(2, ']')
+        new_2 = CharList('fallen off')
+        new_2.pre_format_index(0, '(')
+        new_2.post_format_index(7, ')')
+        overlay_lists(self.l, new_1, 1)
+        overlay_lists(self.l, new_2, 9)
+        self.assertEqual(str(self.l), 'hb[ob]o wor(fa')

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -93,6 +93,13 @@ class TestAB(TestCase):
         self.assertEqual(AB.from_map(plus_one, AB(1, 2)), AB(2, 3))
         self.assertRaises(TypeError, AB.from_map, plus_one, (1, 2, 3))
 
+    def test_map(self):
+        times_two = lambda n: n * 2
+        ab = AB(1, 2)
+        self.assertEqual(ab.map(times_two), AB(2, 4))
+        times_m = lambda n, m: n * m
+        self.assertEqual(ab.map(times_m, 3), AB(3, 6))
+
     def test_attr_lookup_and_call(self):
         ab = AB('hello', 'world')
         print(ab.index)

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -184,9 +184,16 @@ class TestCharList(TestCase):
         self.assertEqual(str(self.l), 'hello world')
 
     def test_format_index(self):
-        self.l.pre_format_index(4, '[')
-        self.l.post_format_index(5, ']')
-        self.assertEqual(str(self.l), 'hell[o ]world')
+        for _ in range(2):
+            self.l.pre_format_index(4, '[')
+            self.l.post_format_index(5, ']')
+            self.assertEqual(str(self.l), 'hell[o ]world')
+        self.l.prepend_format_index(3, ' {')
+        self.l.append_format_index(6, '} ')
+        self.assertEqual(str(self.l), 'hel {l[o ]w} orld')
+        self.l.prepend_format_index(4, '[')
+        self.l.append_format_index(5, ']')
+        self.assertEqual(str(self.l), 'hel {l[[o ]]w} orld')
 
     def test_overlay_char_lists(self):
         new_1 = CharList('bob')

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -195,6 +195,13 @@ class TestCharList(TestCase):
         self.l.append_format_index(5, ']')
         self.assertEqual(str(self.l), 'hel {l[[o ]]w} orld')
 
+    def test_format_index_out_of_bounds(self):
+        for _ in range(2):
+            self.l.pre_format_index(11, '[')
+            self.assertEqual(str(self.l), 'hello world[')
+        self.l.post_format_index(14, ']')
+        self.assertEqual(str(self.l), 'hello world]')
+
     def test_get_format(self):
         self.assertEqual(self.l.get_format(3), '')
         self.l.pre_format_index(1, '[')

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from util import fmt_seconds, overlay_lists, caching_property
+from util import fmt_seconds, overlay_lists, caching_property, AB
 
 
 class TestUtil(TestCase):
@@ -48,3 +48,18 @@ class TestUtil(TestCase):
         self.assertEqual(self.computed, 2)
         self.assertEqual(f2.something, '')
         self.assertEqual(self.computed, 2)
+
+    def test_ab(self):
+        self.assertEqual(AB(1, 2), AB(1, 2))
+        self.assertEqual(AB(1, 2), (1, 2))
+        self.assertNotEqual(AB(1, 2), AB(3, 4))
+        self.assertNotEqual(AB(1, 2), (1, 2, 3))
+        self.assertEqual(AB(1, 2) + AB(3, 2), AB(4, 4))
+        self.assertEqual(AB(1, 2) - AB(3, 2), AB(-2, 0))
+        chars = 'ab'
+        ab = AB(*chars)
+        for i, c in enumerate(chars):
+            self.assertEqual(ab[i], c)
+            self.assertEqual(getattr(ab, c), c)
+            ab[i] = i
+            self.assertEqual(ab[i], i)

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -65,13 +65,17 @@ class TestUtil(TestCase):
         self.assertEqual(f2.something, '')
         self.assertEqual(self.computed, 2)
 
-    def test_ab(self):
+
+class TestAB(TestCase):
+    def test_eq(self):
         self.assertEqual(AB(1, 2), AB(1, 2))
         self.assertEqual(AB(1, 2), (1, 2))
         self.assertNotEqual(AB(1, 2), AB(3, 4))
         self.assertNotEqual(AB(1, 2), (1, 2, 3))
         self.assertEqual(AB(1, 2) + AB(3, 2), AB(4, 4))
         self.assertEqual(AB(1, 2) - AB(3, 2), AB(-2, 0))
+
+    def test_get_set_item(self):
         chars = 'ab'
         ab = AB(*chars)
         for i, c in enumerate(chars):
@@ -79,3 +83,16 @@ class TestUtil(TestCase):
             self.assertEqual(getattr(ab, c), c)
             ab[i] = i
             self.assertEqual(ab[i], i)
+
+    def test_reversed(self):
+        self.assertEqual(AB(1, 2).reversed(), AB(2, 1))
+
+    def test_from_map(self):
+        plus_one = lambda n: n + 1
+        self.assertEqual(AB.from_map(plus_one, AB(1, 2)), AB(2, 3))
+        self.assertRaises(TypeError, AB.from_map, plus_one, (1, 2, 3))
+
+    def test_attr_lookup_and_call(self):
+        ab = AB('hello', 'world')
+        print(ab.index)
+        self.assertEqual(ab.index('l'), AB(2, 3))

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -1,16 +1,32 @@
 from unittest import TestCase
 
-from util import fmt_seconds, overlay_lists, caching_property, AB
+from util import overlay_lists, caching_property, AB, Time
 
 
 class TestUtil(TestCase):
-    def test_fmt_seconds(self):
-        self.assertEqual(fmt_seconds(1.567), '1.57')
-        self.assertEqual(fmt_seconds(59.899), '59.90')
-        self.assertEqual(fmt_seconds(59.999), '1:00.0')
-        self.assertEqual(fmt_seconds(61.789), '1:01.8')
-        self.assertEqual(fmt_seconds(3599.99), '1:00:00')
-        self.assertEqual(fmt_seconds(3601.5), '1:00:02')
+    def test_time(self):
+        v = ValueError()
+        data = (
+            (1.567, '1.57', '1.57', '0:01.6', '0:00:02'),
+            (59.899, '59.90', '59.90', '0:59.9', '0:01:00'),
+            (59.999, '1:00.0', v, '1:00.0', '0:01:00'),
+            (61.789, '1:01.8', v, '1:01.8', '0:01:02'),
+            (3599.99, '1:00:00', v, v, '1:00:00'),
+            (3601.5, '1:00:02', v, v, '1:00:02'),
+        )
+        for seconds, free, fixed_2, fixed_1, fixed_0 in data:
+            self.assertEqual(str(Time.from_seconds(seconds)), free)
+            def check(precision, expected, msg):
+                if isinstance(expected, Exception):
+                    self.assertRaises(
+                        type(expected), Time.from_seconds, seconds, precision)
+                else:
+                    self.assertEqual(
+                        str(Time.from_seconds(seconds, precision)), expected,
+                        msg.format(seconds))
+            check(2, fixed_2, '{} fixed 2')
+            check(1, fixed_1, '{} fixed 1')
+            check(0, fixed_0, '{} fixed 0')
 
     def test_overlay_lists(self):
         data = (

--- a/python/test_util.py
+++ b/python/test_util.py
@@ -49,7 +49,8 @@ class TestUtil(TestCase):
             def __init__(self, return_value):
                 self.return_value = return_value
 
-            @caching_property
+            @property
+            @cache
             def something(instance):
                 self.computed += 1
                 return instance.return_value

--- a/python/util.py
+++ b/python/util.py
@@ -60,11 +60,16 @@ class Clamped:
         max_ = self.max(obj)
         setattr(obj, self.identifier, self._limit(value, min_, max_))
 
+UNASSIGNED = object()
+
 
 class AB:
     __slots__ = '_data',
 
-    def __init__(self, a, b):
+    def __init__(self, a, b=UNASSIGNED):
+        'Takes either values for a and b or a value to repeat for both'
+        if b is UNASSIGNED:
+            b = a
         self._data = [a, b]
 
     def __repr__(self):

--- a/python/util.py
+++ b/python/util.py
@@ -88,10 +88,10 @@ class AB:
         self._data[i] = value
 
     def __getattr__(self, name):
-        return self.from_map(lambda obj: getattr(obj, name), self)
+        return self.map(lambda obj: getattr(obj, name))
 
     def __call__(self, *args, **kwargs):
-        return self.from_map(lambda obj: obj(*args, **kwargs), self)
+        return self.map(lambda obj: obj(*args, **kwargs))
 
     def __add__(self, other):
         return self.__class__(*starmap(add, zip(self, other)))

--- a/python/util.py
+++ b/python/util.py
@@ -111,6 +111,39 @@ class AB:
         return self.__class__(*reversed(self))
 
 
+class FormattedChar:
+    __slots__ = 'pre_fmt', 'c', 'post_fmt'
+
+    def __init__(self, c, pre_fmt='', post_fmt=''):
+        self.pre_fmt = pre_fmt
+        self.c = c
+        self.post_fmt = post_fmt
+
+    def __str__(self):
+        return self.pre_fmt + self.c + self.post_fmt
+
+    def __repr__(self):
+        return 'c({!r}, {!r}, {!r})'.format(
+            self.c, self.pre_fmt, self.post_fmt)
+
+
+class CharList(list):
+    def _format_index(self, i, name, fmt):
+        try:
+            setattr(self[i], name, fmt)
+        except AttributeError:
+            self[i] = FormattedChar(self[i], **{name: fmt})
+
+    def pre_format_index(self, i, fmt):
+        self._format_index(i, 'pre_fmt', fmt)
+
+    def post_format_index(self, i, fmt):
+        self._format_index(i, 'post_fmt', fmt)
+
+    def __str__(self):
+        return ''.join(map(str, self))
+
+
 class Time(namedtuple('Time', ('hours', 'minutes', 'seconds', 'precision'))):
     '''Handle rounding and pretty formatting of time. Precision has two related
     meanings:

--- a/python/util.py
+++ b/python/util.py
@@ -175,6 +175,13 @@ class CharList(list):
         'Replace the format after the indexed character'
         self._format_index(i, 'post_fmt', fmt)
 
+    def get_format(self, i):
+        'Get the latest format string to be applied to the indexed character'
+        for c in self[i::-1]:
+            if hasattr(c, 'pre_fmt'):
+                return c.post_fmt or c.pre_fmt
+        return ''
+
     def __str__(self):
         return ''.join(map(str, self))
 

--- a/python/util.py
+++ b/python/util.py
@@ -34,6 +34,9 @@ class AB(Sequence):
     def __init__(self, a, b):
         self._data = [a, b]
 
+    def __repr__(self):
+        return '{}({}, {})'.format(self.__class__.__name__, *self)
+
     def __len__(self):
         return len(self._data)
 

--- a/python/util.py
+++ b/python/util.py
@@ -4,15 +4,14 @@ from itertools import starmap
 from operator import add, sub, eq
 
 
-def caching_property(method):
+def cache(method):
     attr_name = '_' + method.__name__
-    @property
     @wraps(method)
-    def new_property(self):
+    def new_method(self):
         if not hasattr(self, attr_name):
             setattr(self, attr_name, method(self))
         return getattr(self, attr_name)
-    return new_property
+    return new_method
 
 
 def overlay_lists(base, new, offset):

--- a/python/util.py
+++ b/python/util.py
@@ -149,6 +149,9 @@ class FormattedChar:
 
 class CharList(list):
     def _format_index(self, i, name, fmt, add=False):
+        if i >= len(self):
+            i = len(self) - 1
+            name = 'post_fmt'
         try:
             existing_fmt = getattr(self[i], name)
         except AttributeError:

--- a/python/util.py
+++ b/python/util.py
@@ -72,7 +72,7 @@ class AB:
     __slots__ = '_data',
 
     def __init__(self, a, b=UNASSIGNED):
-        'Takes either values for a and b or a value to repeat for both'
+        '''Takes either values for a and b or a value to repeat for both'''
         if b is UNASSIGNED:
             b = a
         self._data = [a, b]
@@ -163,23 +163,24 @@ class CharList(list):
             setattr(self[i], name, fmt)
 
     def prepend_format_index(self, i, fmt):
-        'Add a format before the indexed character'
+        '''Add a format before the indexed character'''
         self._format_index(i, 'pre_fmt', fmt, add=True)
 
     def pre_format_index(self, i, fmt):
-        'Replace the format before the indexed character'
+        '''Replace the format before the indexed character'''
         self._format_index(i, 'pre_fmt', fmt)
 
     def append_format_index(self, i, fmt):
-        'Add a format after the indexed character'
+        '''Add a format after the indexed character'''
         self._format_index(i, 'post_fmt', fmt, add=True)
 
     def post_format_index(self, i, fmt):
-        'Replace the format after the indexed character'
+        '''Replace the format after the indexed character'''
         self._format_index(i, 'post_fmt', fmt)
 
     def get_format(self, i):
-        'Get the latest format string to be applied to the indexed character'
+        '''Get the latest format string to be applied to the indexed character
+        '''
         for c in self[i::-1]:
             if hasattr(c, 'pre_fmt'):
                 return c.post_fmt or c.pre_fmt

--- a/python/util.py
+++ b/python/util.py
@@ -1,0 +1,78 @@
+from functools import wraps
+
+
+def caching_property(method):
+    attr_name = '_' + method.__name__
+    @property
+    @wraps(method)
+    def new_property(self):
+        if not getattr(self, attr_name):
+            setattr(self, attr_name, method(self))
+        return getattr(self, attr_name)
+    return new_property
+
+
+def overlay_lists(base, new, offset):
+    '''Mutates the given base list by overlaying the new list on top at a given
+    offset.
+    '''
+    if offset + len(new) >= 0:
+        for i in range(len(new)):
+            base_idx = i + offset
+            if 0 <= base_idx < len(base):
+                base[base_idx] = new[i]
+            elif base_idx >= len(base):
+                break
+
+
+class Time:
+    '''Formats the given time in seconds to an appropriate prescision excluding
+    leading zero components. Edge cases around overflowing make this
+    non-trivial.
+    '''
+
+    __slots__ = 'hours', 'minutes', 'seconds'
+
+    def __init__(self, seconds):
+        self.hours, self.minutes, self.seconds = self._round_hms(
+            *self._split(seconds))
+
+    @staticmethod
+    def _split(seconds):
+        hours, remainder = divmod(seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        return hours, minutes, seconds
+
+    @staticmethod
+    def _round_pair(big, small, precision):
+        if round(small, precision) == 60:
+            big += 1
+            small = 0.0
+        return big, small
+
+    @staticmethod
+    def _select(hours, minutes, seconds, a, b, c):
+        if not hours:
+            if not minutes:
+                return c
+            return b
+        return a
+
+    def _round_hms(self, hours, minutes, seconds):
+        second_prec = self._select(hours, minutes, seconds, 0, 1, 2)
+        minutes, seconds = self._round_pair(minutes, seconds, second_prec)
+        hours, minutes = self._round_pair(hours, minutes, 0)
+        return hours, minutes, seconds
+
+    def __str__(self):
+        fmt_str = self._select(
+            self.hours, self.minutes, self.seconds,
+            '{hours:.0f}:{minutes:02.0f}:{seconds:02.0f}',
+            '{minutes:.0f}:{seconds:04.1f}',
+            '{seconds:.2f}')
+        return fmt_str.format(
+            hours=self.hours, minutes=self.minutes, seconds=self.seconds)
+
+
+def fmt_seconds(seconds):
+    return str(Time(seconds))

--- a/python/util.py
+++ b/python/util.py
@@ -104,6 +104,9 @@ class AB:
     def from_map(cls, func, iterable):
         return cls(*map(func, iterable))
 
+    def map(self, func, *args, **kwargs):
+        return self.from_map(lambda i: func(i, *args, **kwargs), self)
+
     def reversed(self):
         return self.__class__(*reversed(self))
 

--- a/python/util.py
+++ b/python/util.py
@@ -46,10 +46,20 @@ class Clamped:
         else:
             return getattr(obj, self.identifier)
 
+    @staticmethod
+    def _limit(value, min_, max_):
+        if min_ is None and max_ is None:
+            return value
+        if min_ is None:
+            min_ = min(value, max_)
+        if max_ is None:
+            max_ = max(value, min_)
+        return sorted((value, min_, max_))[1]
+
     def __set__(self, obj, value):
-        setattr(
-            obj, self.identifier,
-            sorted((self.min(obj), value, self.max(obj)))[1])
+        min_ = self.min(obj)
+        max_ = self.max(obj)
+        setattr(obj, self.identifier, self._limit(value, min_, max_))
 
 
 class AB:

--- a/python/util.py
+++ b/python/util.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from collections import Sequence, namedtuple
+from collections import namedtuple
 from itertools import starmap
 from operator import add, sub, eq
 

--- a/python/util.py
+++ b/python/util.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from collections import Sequence
+from collections import Sequence, namedtuple
 from itertools import starmap
 from operator import add, sub, eq
 
@@ -55,55 +55,74 @@ class AB(Sequence):
     a = property(lambda self: self[0])
     b = property(lambda self: self[1])
 
+    @classmethod
+    def from_map(cls, func, iterable):
+        return cls(*map(func, iterable))
 
-class Time:
-    '''Formats the given time in seconds to an appropriate prescision excluding
-    leading zero components. Edge cases around overflowing make this
-    non-trivial.
+
+class Time(namedtuple('Time', ('hours', 'minutes', 'seconds', 'precision'))):
+    '''Handle rounding and pretty formatting of time. Precision has two related
+    meanings:
+    1. The number of decimal places to which to render seconds
+    2. Which units to show in the output
+    Because of this strong coupling, you can't ask for a "hour-like" time at a
+    high precision.
+
+    Calculating the exact breakdown into hours, minutes and seconds components
+    is complicated by the fact that the precision to which we want to round the
+    seconds component is dependent on whether the seconds component overflows
+    at a given precision!
     '''
+    _formats = {
+        0: '{t.hours:.0f}:{t.minutes:02.0f}:{t.seconds:02.0f}',
+        1: '{t.minutes:.0f}:{t.seconds:04.1f}',
+        2: '{t.seconds:.2f}',
+    }
 
-    __slots__ = 'hours', 'minutes', 'seconds'
+    def __new__(cls, hours, minutes, seconds, target_precision=None):
+        if target_precision is None:
+            precision = cls._get_precision(hours, minutes, seconds)
+        else:
+            precision = target_precision
+        hours, minutes, seconds = cls._round(
+            hours, minutes, seconds, precision)
+        precision = cls._get_precision(hours, minutes, seconds)
+        if target_precision is not None:
+            if precision < target_precision:
+                raise ValueError("Precision too high for large time")
+            else:
+                precision = target_precision
+        return super().__new__(cls, hours, minutes, seconds, precision)
 
-    def __init__(self, seconds):
-        self.hours, self.minutes, self.seconds = self._round_hms(
-            *self._split(seconds))
-
-    @staticmethod
-    def _split(seconds):
+    @classmethod
+    def from_seconds(cls, seconds, precision=None):
         hours, remainder = divmod(seconds, 3600)
         minutes, seconds = divmod(remainder, 60)
-        return hours, minutes, seconds
+        return cls(hours, minutes, seconds, precision)
 
     @staticmethod
-    def _round_pair(big, small, precision):
+    def _get_precision(hours, minutes, seconds):
+        if not hours:
+            if not minutes:
+                return 2
+            return 1
+        return 0
+
+    @staticmethod
+    def _overflow(big, small, precision):
         if round(small, precision) == 60:
             big += 1
             small = 0.0
         return big, small
 
-    @staticmethod
-    def _select(hours, minutes, seconds, a, b, c):
-        if not hours:
-            if not minutes:
-                return c
-            return b
-        return a
-
-    def _round_hms(self, hours, minutes, seconds):
-        second_prec = self._select(hours, minutes, seconds, 0, 1, 2)
-        minutes, seconds = self._round_pair(minutes, seconds, second_prec)
-        hours, minutes = self._round_pair(hours, minutes, 0)
+    @classmethod
+    def _round(cls, hours, minutes, seconds, precision):
+        minutes, seconds = cls._overflow(minutes, seconds, precision)
+        hours, minutes = cls._overflow(hours, minutes, 0)
         return hours, minutes, seconds
 
     def __str__(self):
-        fmt_str = self._select(
-            self.hours, self.minutes, self.seconds,
-            '{hours:.0f}:{minutes:02.0f}:{seconds:02.0f}',
-            '{minutes:.0f}:{seconds:04.1f}',
-            '{seconds:.2f}')
-        return fmt_str.format(
-            hours=self.hours, minutes=self.minutes, seconds=self.seconds)
-
-
-def fmt_seconds(seconds):
-    return str(Time(seconds))
+        '''Formats the given time in seconds to an appropriate or given
+        prescision excluding leading zero components.
+        '''
+        return self._formats[self.precision].format(t=self)

--- a/python/util.py
+++ b/python/util.py
@@ -28,7 +28,7 @@ def overlay_lists(base, new, offset):
                 break
 
 
-class AB(Sequence):
+class AB:
     __slots__ = '_data',
 
     def __init__(self, a, b):
@@ -36,6 +36,9 @@ class AB(Sequence):
 
     def __repr__(self):
         return '{}({}, {})'.format(self.__class__.__name__, *self)
+
+    def __iter__(self):
+        return iter(self._data)
 
     def __len__(self):
         return len(self._data)
@@ -45,6 +48,12 @@ class AB(Sequence):
 
     def __setitem__(self, i, value):
         self._data[i] = value
+
+    def __getattr__(self, name):
+        return self.from_map(lambda obj: getattr(obj, name), self)
+
+    def __call__(self, *args, **kwargs):
+        return self.from_map(lambda obj: obj(*args, **kwargs), self)
 
     def __add__(self, other):
         return self.__class__(*starmap(add, zip(self, other)))

--- a/python/util.py
+++ b/python/util.py
@@ -252,6 +252,6 @@ class Time(namedtuple('Time', ('hours', 'minutes', 'seconds', 'precision'))):
 
     def __str__(self):
         '''Formats the given time in seconds to an appropriate or given
-        prescision excluding leading zero components.
+        precision excluding leading zero components.
         '''
         return self._formats[self.precision].format(t=self)

--- a/python/util.py
+++ b/python/util.py
@@ -1,4 +1,7 @@
 from functools import wraps
+from collections import Sequence
+from itertools import starmap
+from operator import add, sub, eq
 
 
 def caching_property(method):
@@ -23,6 +26,34 @@ def overlay_lists(base, new, offset):
                 base[base_idx] = new[i]
             elif base_idx >= len(base):
                 break
+
+
+class AB(Sequence):
+    __slots__ = '_data',
+
+    def __init__(self, a, b):
+        self._data = [a, b]
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, i):
+        return self._data[i]
+
+    def __setitem__(self, i, value):
+        self._data[i] = value
+
+    def __add__(self, other):
+        return self.__class__(*starmap(add, zip(self, other)))
+
+    def __sub__(self, other):
+        return self.__class__(*starmap(sub, zip(self, other)))
+
+    def __eq__(self, other):
+        return len(self) == len(other) and all(starmap(eq, zip(self, other)))
+
+    a = property(lambda self: self[0])
+    b = property(lambda self: self[1])
 
 
 class Time:

--- a/python/util.py
+++ b/python/util.py
@@ -6,7 +6,7 @@ def caching_property(method):
     @property
     @wraps(method)
     def new_property(self):
-        if not getattr(self, attr_name):
+        if not hasattr(self, attr_name):
             setattr(self, attr_name, method(self))
         return getattr(self, attr_name)
     return new_property

--- a/python/util.py
+++ b/python/util.py
@@ -59,6 +59,9 @@ class AB(Sequence):
     def from_map(cls, func, iterable):
         return cls(*map(func, iterable))
 
+    def reversed(self):
+        return self.__class__(*reversed(self))
+
 
 class Time(namedtuple('Time', ('hours', 'minutes', 'seconds', 'precision'))):
     '''Handle rounding and pretty formatting of time. Precision has two related

--- a/python/util.py
+++ b/python/util.py
@@ -28,6 +28,30 @@ def overlay_lists(base, new, offset):
                 break
 
 
+class Clamped:
+    '''Descriptor that limits the range of an attribute, given two callbacks
+    values or callbacks for minimum values.
+    '''
+    def __init__(self, min_, max_):
+        self.min = min_ if callable(min_) else lambda _: min_
+        self.max = max_ if callable(max_) else lambda _: max_
+
+    @property
+    def identifier(self):
+        return '_{:x}'.format(id(self))
+
+    def __get__(self, obj, type_):
+        if obj is None:
+            return self
+        else:
+            return getattr(obj, self.identifier)
+
+    def __set__(self, obj, value):
+        setattr(
+            obj, self.identifier,
+            sorted((self.min(obj), value, self.max(obj)))[1])
+
+
 class AB:
     __slots__ = '_data',
 

--- a/python/util.py
+++ b/python/util.py
@@ -148,16 +148,31 @@ class FormattedChar:
 
 
 class CharList(list):
-    def _format_index(self, i, name, fmt):
+    def _format_index(self, i, name, fmt, add=False):
         try:
-            setattr(self[i], name, fmt)
+            existing_fmt = getattr(self[i], name)
         except AttributeError:
             self[i] = FormattedChar(self[i], **{name: fmt})
+            existing_fmt = ''
+        else:
+            if add:
+                fmt = existing_fmt + fmt
+            setattr(self[i], name, fmt)
+
+    def prepend_format_index(self, i, fmt):
+        'Add a format before the indexed character'
+        self._format_index(i, 'pre_fmt', fmt, add=True)
 
     def pre_format_index(self, i, fmt):
+        'Replace the format before the indexed character'
         self._format_index(i, 'pre_fmt', fmt)
 
+    def append_format_index(self, i, fmt):
+        'Add a format after the indexed character'
+        self._format_index(i, 'post_fmt', fmt, add=True)
+
     def post_format_index(self, i, fmt):
+        'Replace the format after the indexed character'
         self._format_index(i, 'post_fmt', fmt)
 
     def __str__(self):

--- a/python/util.py
+++ b/python/util.py
@@ -64,6 +64,11 @@ UNASSIGNED = object()
 
 
 class AB:
+    '''Vector like class to help process multiple related values together.
+    Provides useful functionality like mapped attribute lookups and
+    distributive calling.
+    '''
+
     __slots__ = '_data',
 
     def __init__(self, a, b=UNASSIGNED):

--- a/python/util.py
+++ b/python/util.py
@@ -93,6 +93,16 @@ class AB:
     def __call__(self, *args, **kwargs):
         return self.map(lambda obj: obj(*args, **kwargs))
 
+    def distribute(self, *iterables):
+        '''Like ab(arg1, arg2...), but we distribute the (iterable) arguments to
+        each respective ab:
+          ab[0](arg1[0], arg2[0]...)
+          ab[1](arg1[1], arg2[1]...)
+        '''
+        iterators = tuple(map(iter, iterables))
+        f_on_next_i = lambda f: f(*map(next, iterators))
+        return self.map(f_on_next_i)
+
     def __add__(self, other):
         return self.__class__(*starmap(add, zip(self, other)))
 


### PR DESCRIPTION
This enriches the command line diff display to highlight more clearly changes vs insertions (as we mocked out ages ago). We then add some interactivity for:
* moving cue points (`[`, `arrow` or `]`, `arrow`)
* moving cue points to hunks (`tab` or `shift + tab`)
* moving the cursor and zooming (`arrow`, `home`, `end`, `esc`).

These don't do anything useful in-and-of-themselves yet, but do provide some rudimentary navigation of the diff.