### PR TITLE
Get the diff semantically correct in highly repetitive data

### DIFF
--- a/src/bdiff.c
+++ b/src/bdiff.c
@@ -102,9 +102,9 @@ static unsigned slidey_aligner(
         if (i != sample_size) {
             continue;
         }
-        unsigned const fsd = find_start_delta(
+        unsigned const start_delta = find_start_delta(
             df, sample_size, buf_fixed, buf_sliding, fixed, sliding);
-        if (slide_distance == min(slide_distance, fsd)) {
+        if (slide_distance == min(slide_distance, start_delta)) {
             break;
         }
     }
@@ -136,8 +136,7 @@ hunk * const bdiff_narrow(
                     rough_hunks->a.end - rough_hunks->a.start,
                     max_chunk_size));
             precise_hunks_tail->b.end -= end_shove_a;
-        }
-        if (end_shove_b) {
+        } else if (end_shove_b) {
             end_shove_b = slidey_aligner(
                 sample_size, ds, df, buf_b, buf_a, b, a,
                 rough_hunks->b.start, precise_hunks_tail->a.end,
@@ -158,7 +157,7 @@ hunk * const bdiff_narrow(
                     rough_hunks->b.end) &&
                 ((rough_hunks->a.start + end_shove_a) ==
                     rough_hunks->a.end)) {
-            // Hunk that contains nothing in either
+            // Discard a hunk that after narrowing contains nothing in either
             end_shove_a = end_shove_b = 0;
             continue;
         }

--- a/src/bdiff.c
+++ b/src/bdiff.c
@@ -88,17 +88,16 @@ static unsigned slidey_aligner(
         ds(fixed, fixed_start);
         assert(df(fixed, buf_fixed, 1) == 1);
         assert(df(sliding, buf_sliding, 1) == 1);
-        int cont = 0;
-        for (unsigned i=0; i < sample_size; i++) {
+        unsigned i = 0;
+        for (; i < sample_size; i++) {
             if (buf_fixed[i] != buf_sliding[i]) {
-                cont = 1;
                 break;
             }
         }
-        if (cont) {
+        if (i != sample_size) {
             continue;
         }
-        unsigned fsd = find_start_delta(
+        unsigned const fsd = find_start_delta(
             df, sample_size, buf_fixed, buf_sliding, fixed, sliding);
         if (slide_distance == min(slide_distance, fsd)) {
             break;

--- a/src/bdiff.c
+++ b/src/bdiff.c
@@ -19,8 +19,13 @@ hunk * const bdiff_rough(
 
 static const unsigned buf_size = 8192;
 
-static inline unsigned min(unsigned a, unsigned b) {
+static inline unsigned min(unsigned const a, unsigned const b) {
     return (a < b) ? a : b;
+}
+
+static inline unsigned min3(
+        unsigned const a, unsigned const b, unsigned const c) {
+    return min(min(a, b), c);
 }
 
 static inline unsigned max(unsigned a, unsigned b) {
@@ -126,22 +131,20 @@ hunk * const bdiff_narrow(
             end_shove_a = slidey_aligner(
                 sample_size, ds, df, buf_a, buf_b, a, b,
                 rough_hunks->a.start, precise_hunks_tail->b.end,
-                min(
+                min3(
                     precise_hunks_tail->b.end - precise_hunks_tail->b.start,
-                    min(
-                        rough_hunks->a.end - rough_hunks->a.start,
-                        max_chunk_size)));
+                    rough_hunks->a.end - rough_hunks->a.start,
+                    max_chunk_size));
             precise_hunks_tail->b.end -= end_shove_a;
         }
         if (end_shove_b) {
             end_shove_b = slidey_aligner(
                 sample_size, ds, df, buf_b, buf_a, b, a,
                 rough_hunks->b.start, precise_hunks_tail->a.end,
-                min(
+                min3(
                     precise_hunks_tail->a.end - precise_hunks_tail->a.start,
-                    min(
-                        rough_hunks->b.end - rough_hunks->b.start,
-                        max_chunk_size)));
+                    rough_hunks->b.end - rough_hunks->b.start,
+                    max_chunk_size));
             precise_hunks_tail->a.end -= end_shove_b;
         }
         ds(a, rough_hunks->a.start + end_shove_a);
@@ -172,10 +175,10 @@ hunk * const bdiff_narrow(
         assert(!(end_shove_a && end_shove_b));
         precise_hunks_tail->a.end += max(end_shove_a, end_shove_b);
         precise_hunks_tail->b.end += max(end_shove_a, end_shove_b);
-        unsigned end_delta = min(
+        unsigned end_delta = min3(
             precise_hunks_tail->a.end - precise_hunks_tail->a.start,
-            precise_hunks_tail->b.end - precise_hunks_tail->b.start);
-        end_delta = min(end_delta, max_chunk_size);
+            precise_hunks_tail->b.end - precise_hunks_tail->b.start,
+            max_chunk_size);
         if (end_delta) {
             ds(a, precise_hunks_tail->a.end - end_delta);
             ds(b, precise_hunks_tail->b.end - end_delta);

--- a/src/bdiff.c
+++ b/src/bdiff.c
@@ -6,6 +6,11 @@
 
 static unsigned const max_chunk_size = 10000;
 
+/*
+ * Perform a chunk based diff of two binary streams.
+ * This method has algorithmic complexity
+ * O(length_stream_a + length_stream_b).
+ */
 hunk * const bdiff_rough(
         unsigned const sample_size, data_fetcher const df, void * const a,
         void * const b) {
@@ -32,6 +37,10 @@ static inline unsigned max(unsigned const a, unsigned const b) {
     return (a > b) ? a : b;
 }
 
+/*
+ * Search through two file sections from an aligned point returning the first
+ * differing sample relative to the start of the sections.
+ */
 static unsigned find_start_delta(
         data_fetcher const df, unsigned const sample_size, char * const buf_a,
         char * const buf_b, void * const a, void * const b) {
@@ -60,6 +69,10 @@ static unsigned find_start_delta(
     }
 }
 
+/*
+ * Search through two segments that should realign by end_delta reporting the
+ * position of last differing sample.
+ */
 static unsigned find_end_delta(
         data_fetcher const df, unsigned const sample_size, unsigned end_delta,
         char * const buf_a, char * const buf_b, void * const a,
@@ -82,6 +95,10 @@ static unsigned find_end_delta(
     return end_delta;
 }
 
+/*
+ * Scan for the start of the "fixed" sequence at the end of the given region of
+ * the "sliding" sequence.
+ */
 static unsigned slidey_aligner(
         unsigned const sample_size, data_seeker const ds,
         data_fetcher const df, char * const buf_fixed,
@@ -111,6 +128,9 @@ static unsigned slidey_aligner(
     return slide_distance;
 }
 
+/*
+ * Subtract 2 unsigned numbers returning 0 when we would otherwise underflow.
+ */
 static inline unsigned clamped_subtract(unsigned const a, unsigned const b) {
     return (a > b) ? a - b : 0;
 }
@@ -190,6 +210,9 @@ hunk * const bdiff_narrow(
     return precise_hunks_head;
 }
 
+/*
+ * Find a semantically correct binary diff of two streams.
+ */
 hunk * const bdiff(
         unsigned const sample_size, data_seeker const ds,
         data_fetcher const df, void * const a, void * const b) {

--- a/src/bdiff.c
+++ b/src/bdiff.c
@@ -106,6 +106,10 @@ static unsigned slidey_aligner(
     return slide_distance;
 }
 
+static inline unsigned clamped_subtract(unsigned const a, unsigned const b) {
+    return (a > b) ? a - b : 0;
+}
+
 /*
  * Takes a set of "rough" hunks (start and end points aligned to chunk
  * boundaries) and reads the data around the start and end points to narrow
@@ -161,15 +165,10 @@ hunk * const bdiff_narrow(
             rough_hunks->a.end,
             rough_hunks->b.start + end_shove_b,
             rough_hunks->b.end);
-        end_shove_a = end_shove_b = 0;
-        if (precise_hunks_tail->a.start > precise_hunks_tail->a.end) {
-            end_shove_a =
-                precise_hunks_tail->a.start - precise_hunks_tail->a.end;
-        }
-        if (precise_hunks_tail->b.start > precise_hunks_tail->b.end) {
-            end_shove_b =
-                precise_hunks_tail->b.start - precise_hunks_tail->b.end;
-        }
+        end_shove_a = clamped_subtract(
+            precise_hunks_tail->a.start, precise_hunks_tail->a.end);
+        end_shove_b = clamped_subtract(
+            precise_hunks_tail->b.start, precise_hunks_tail->b.end);
         assert(!(end_shove_a && end_shove_b));
         precise_hunks_tail->a.end += max(end_shove_a, end_shove_b);
         precise_hunks_tail->b.end += max(end_shove_a, end_shove_b);

--- a/src/bdiff.c
+++ b/src/bdiff.c
@@ -28,7 +28,7 @@ static inline unsigned min3(
     return min(min(a, b), c);
 }
 
-static inline unsigned max(unsigned a, unsigned b) {
+static inline unsigned max(unsigned const a, unsigned const b) {
     return (a > b) ? a : b;
 }
 

--- a/tests/unittest_bdiff.c
+++ b/tests/unittest_bdiff.c
@@ -264,10 +264,13 @@ static void bdiff_combined_insertion_same_either_side() {
     Build_narrowable_data(ndb, 1, Arr(200), Arr(0));
     hunk * hunks = bdiff(
         sizeof(unsigned), narrowable_seeker, narrowable_fetcher, &nda, &ndb);
-    g_assert_cmpuint(hunks->a.start, ==, 151);
-    g_assert_cmpuint(hunks->a.end, ==, 651);
-    g_assert_cmpuint(hunks->b.start, ==, 151);
-    g_assert_cmpuint(hunks->b.end, ==, 151);
+    assert_hunk_eq(hunks, 151, 651, 151, 151);
+    g_assert_null(hunks->next);
+    hunk_free(hunks);
+    nda.pos = ndb.pos = 0;
+    hunks = bdiff(
+        sizeof(unsigned), narrowable_seeker, narrowable_fetcher, &ndb, &nda);
+    assert_hunk_eq(hunks, 151, 151, 151, 651);
     g_assert_null(hunks->next);
     hunk_free(hunks);
 }

--- a/tests/unittest_bdiff.c
+++ b/tests/unittest_bdiff.c
@@ -60,7 +60,7 @@ static unsigned narrowable_fetcher(
 
 static void narrowable_seeker(void * source, unsigned pos) {
     narrowable_data * nd = source;
-    g_assert_cmpuint(pos, <=, nd->from[nd->n_values - 1]);
+    g_assert_cmpuint(pos, <=, nd->from[nd->n_values - 1] + 1);
     nd->pos = pos;
 }
 

--- a/tests/unittest_bdiff.c
+++ b/tests/unittest_bdiff.c
@@ -252,16 +252,10 @@ static void bdiff_combined_insertion_same_either_side() {
     hunk * hunks = bdiff(
         sizeof(unsigned), narrowable_seeker, narrowable_fetcher, &nda, &ndb);
     g_assert_cmpuint(hunks->a.start, ==, 151);
-    g_assert_cmpuint(hunks->a.end, >=, 651);
+    g_assert_cmpuint(hunks->a.end, ==, 651);
     g_assert_cmpuint(hunks->b.start, ==, 151);
     g_assert_cmpuint(hunks->b.end, ==, 151);
-    // Because the chunking doesn't quite line up with the boundaries the first
-    // hunk contains some common parts, so we check that what was missing is
-    // counteracted at the end so the diff will patch correctly.
-    unsigned const ahead_by = hunks->a.end - 651;
-    g_assert_cmpuint(ahead_by, <, 201);
-    assert_hunk_eq(hunks->next, 701, 701, 201 - ahead_by, 201);
-    g_assert_null(hunks->next->next);
+    g_assert_null(hunks->next);
     hunk_free(hunks);
 }
 

--- a/tests/unittest_bdiff.c
+++ b/tests/unittest_bdiff.c
@@ -135,6 +135,19 @@ static void narrowing_insertion() {
     hunk_free(precise_hunks);
 }
 
+static void insertion_at_end() {
+    Build_narrowable_data(nda, 2, Arr(14, 19), Arr(0, 1));
+    Build_narrowable_data(ndb, 1, Arr(14), Arr(0));
+    hunk rough_hunks = (hunk) {
+        .a = {.start = 15, .end = 20}, .b = {.start = 15, .end = 15}};
+    hunk * precise_hunks = bdiff_narrow(
+        &rough_hunks, sizeof(unsigned), narrowable_seeker, narrowable_fetcher,
+        &nda, &ndb);
+    assert_hunk_eq(precise_hunks, 15, 20, 15, 15);
+    g_assert_null(precise_hunks->next);
+    hunk_free(precise_hunks);
+}
+
 static void narrowing_change_over_start() {
     Build_narrowable_data(nda, 2, Arr(15, 30), Arr(2, 1));
     Build_narrowable_data(ndb, 2, Arr(17, 32), Arr(3, 1));
@@ -272,6 +285,7 @@ int main(int argc, char **argv) {
     g_test_add_func("/bdiff/narrow", narrowing);
     g_test_add_func("/bdiff/narrow_sizes_differ", narrowing_differing_sizes);
     g_test_add_func("/bdiff/narrow_insertion", narrowing_insertion);
+    g_test_add_func("/bdiff/insertion_at_end", insertion_at_end);
     g_test_add_func("/bdiff/narrow_over_start", narrowing_change_over_start);
     g_test_add_func("/bdiff/narrow_is_start", narrowing_change_is_start);
     g_test_add_func("/bdiff/narrow_over_end", narrowing_change_over_end);


### PR DESCRIPTION
This is by no means optimised, however I think it should work.